### PR TITLE
Composable Functions

### DIFF
--- a/.sizesnap.json
+++ b/.sizesnap.json
@@ -1,102 +1,37 @@
 {
-	"dist/index.d.ts": {
-		"size": "1.676KB",
-		"brotli": "461B",
-		"gzip": "535B"
-	},
-	"dist/index.js": {
-		"size": "10.218KB",
-		"brotli": "2.661KB",
-		"gzip": "3.055KB"
-	},
-	"dist/index.js.map": {
-		"size": "10.643KB",
-		"brotli": "1.597KB",
-		"gzip": "1.78KB"
-	},
-	"dist/index.min.js": {
-		"size": "4.153KB",
-		"brotli": "1.72KB",
-		"gzip": "1.967KB"
-	},
-	"dist/lib/color.d.ts": {
-		"size": "59B",
-		"brotli": "55B",
-		"gzip": "72B"
-	},
-	"dist/lib/color.js": {
-		"size": "530B",
-		"brotli": "232B",
-		"gzip": "297B"
-	},
-	"dist/lib/color.js.map": {
-		"size": "579B",
-		"brotli": "234B",
-		"gzip": "258B"
-	},
-	"dist/lib/math.d.ts": {
-		"size": "80B",
-		"brotli": "59B",
-		"gzip": "86B"
-	},
-	"dist/lib/math.js": {
-		"size": "574B",
-		"brotli": "241B",
-		"gzip": "295B"
-	},
-	"dist/lib/math.js.map": {
-		"size": "542B",
-		"brotli": "242B",
-		"gzip": "268B"
-	},
-	"esm/index.d.ts": {
-		"size": "1.676KB",
-		"brotli": "461B",
-		"gzip": "535B"
-	},
-	"esm/index.js": {
-		"size": "9.512KB",
-		"brotli": "2.466KB",
-		"gzip": "2.859KB"
-	},
-	"esm/index.js.map": {
-		"size": "10.558KB",
-		"brotli": "1.544KB",
-		"gzip": "1.705KB"
-	},
-	"esm/index.min.js": {
-		"size": "3.28KB",
-		"brotli": "1.434KB",
-		"gzip": "1.63KB"
-	},
-	"esm/lib/color.d.ts": {
-		"size": "59B",
-		"brotli": "55B",
-		"gzip": "72B"
-	},
-	"esm/lib/color.js": {
-		"size": "392B",
-		"brotli": "177B",
-		"gzip": "227B"
-	},
-	"esm/lib/color.js.map": {
-		"size": "569B",
-		"brotli": "239B",
-		"gzip": "250B"
-	},
-	"esm/lib/math.d.ts": {
-		"size": "80B",
-		"brotli": "59B",
-		"gzip": "86B"
-	},
-	"esm/lib/math.js": {
-		"size": "397B",
-		"brotli": "191B",
-		"gzip": "225B"
-	},
-	"esm/lib/math.js.map": {
-		"size": "532B",
-		"brotli": "228B",
-		"gzip": "259B"
-	}
+  "dist/chunk-MGU2KWPZ.mjs": {
+    "size": "8.452KB",
+    "brotli": "2.262KB",
+    "gzip": "2.568KB"
+  },
+  "dist/compose.d.ts": {
+    "size": "674B",
+    "brotli": "219B",
+    "gzip": "242B"
+  },
+  "dist/compose.js": {
+    "size": "9.421KB",
+    "brotli": "2.551KB",
+    "gzip": "2.912KB"
+  },
+  "dist/compose.mjs": {
+    "size": "1.209KB",
+    "brotli": "282B",
+    "gzip": "340B"
+  },
+  "dist/index.d.ts": {
+    "size": "1.741KB",
+    "brotli": "507B",
+    "gzip": "584B"
+  },
+  "dist/index.js": {
+    "size": "9.822KB",
+    "brotli": "2.68KB",
+    "gzip": "3.033KB"
+  },
+  "dist/index.mjs": {
+    "size": "390B",
+    "brotli": "130B",
+    "gzip": "141B"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@barelyhuman/prettier-config": "^0.1.0",
 				"prettier": "^2.5.1",
 				"rimraf": "^3.0.2",
-				"sizesnap": "^0.1.0",
+				"sizesnap": "^0.2.1",
 				"tsm": "^2.2.1",
 				"tsup": "^6.7.0",
 				"typescript": "^4.5.5",
@@ -1669,11 +1669,10 @@
 			"dev": true
 		},
 		"node_modules/sizesnap": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/sizesnap/-/sizesnap-0.1.1.tgz",
-			"integrity": "sha512-Srr/zwX61DU6Unra6GVbpZlPw3yP+5p8nN+ZqHh2axr/zDFVevpUthHsURw5h8fhYWNVlNv2B18hntnVWH24OA==",
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/sizesnap/-/sizesnap-0.2.1.tgz",
+			"integrity": "sha512-PaAbYpT+ZWc2NssIjl2CzIUGIqG36uVVv8cR8ImweYeLOXsJOB8F136r4pJcUpk+4nU92X4DoKu5ZumDrCqTKw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"tar": "^6.1.11"
 			},
@@ -3094,9 +3093,9 @@
 			"dev": true
 		},
 		"sizesnap": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/sizesnap/-/sizesnap-0.1.1.tgz",
-			"integrity": "sha512-Srr/zwX61DU6Unra6GVbpZlPw3yP+5p8nN+ZqHh2axr/zDFVevpUthHsURw5h8fhYWNVlNv2B18hntnVWH24OA==",
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/sizesnap/-/sizesnap-0.2.1.tgz",
+			"integrity": "sha512-PaAbYpT+ZWc2NssIjl2CzIUGIqG36uVVv8cR8ImweYeLOXsJOB8F136r4pJcUpk+4nU92X4DoKu5ZumDrCqTKw==",
 			"dev": true,
 			"requires": {
 				"tar": "^6.1.11"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.js",
 			"default": "./dist/index.js"
+		},
+		"./compose": {
+			"import": "./dist/compose.mjs",
+			"require": "./dist/compose.js",
+			"default": "./dist/compose.js"
 		}
 	},
 	"scripts": {
@@ -35,7 +40,7 @@
 		"@barelyhuman/prettier-config": "^0.1.0",
 		"prettier": "^2.5.1",
 		"rimraf": "^3.0.2",
-		"sizesnap": "^0.1.0",
+		"sizesnap": "^0.2.1",
 		"tsm": "^2.2.1",
 		"tsup": "^6.7.0",
 		"typescript": "^4.5.5",
@@ -46,8 +51,7 @@
 	},
 	"sizesnap": {
 		"files": [
-			"./dist/**/*",
-			"./esm/**/*"
+			"./dist/**/*"
 		]
 	}
 }

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,0 +1,61 @@
+import type {HSL, LAB, RGB, XYZ} from './index'
+
+import {
+	hexToHSL as nFP_hexToHSL,
+	hexToRGB as nFP_hexToRGB,
+	hslToHex as nFP_hslToHex,
+	hslToRGB as nFP_hslToRGB,
+	labToRGB as nFP_labToRGB,
+	labToXYZ as nFP_labToXYZ,
+	rgbToHSL as nFP_rgbToHSL,
+	rgbToHex as nFP_rgbToHex,
+	rgbToLAB as nFP_rgbToLAB,
+	rgbToXYZ as nFP_rgbToXYZ,
+	xyzToLAB as nFP_xyzToLAB,
+	xyzToRGB as nFP_xyzToRGB,
+} from './index'
+
+export function rgbToHex(o: RGB) {
+	return nFP_rgbToHex(o.r, o.g, o.b)
+}
+export function hslToHex(o: HSL) {
+	return nFP_hslToHex(o.h, o.s, o.l)
+}
+export function hslToRGB(o: HSL) {
+	return nFP_hslToRGB(o.h, o.s, o.l)
+}
+
+export function rgbToHSL(o: RGB) {
+	return nFP_rgbToHSL(o.r, o.g, o.b)
+}
+export function hexToRGB(o: string) {
+	return nFP_hexToRGB(o)
+}
+
+export function hexToHSL(o: string) {
+	return nFP_hexToHSL(o)
+}
+
+export function rgbToXYZ(o: RGB) {
+	return nFP_rgbToXYZ(o.r, o.g, o.b)
+}
+
+export function xyzToLAB(o: XYZ) {
+	return nFP_xyzToLAB(o.x, o.y, o.z)
+}
+
+export function rgbToLAB(o: RGB) {
+	return nFP_rgbToLAB(o.r, o.g, o.b)
+}
+
+export function labToXYZ(o: LAB) {
+	return nFP_labToXYZ(o.l, o.a, o.b)
+}
+
+export function xyzToRGB(o: XYZ) {
+	return nFP_xyzToRGB(o.x, o.y, o.z)
+}
+
+export function labToRGB(o: LAB) {
+	return nFP_labToRGB(o.l, o.a, o.b)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,25 +34,25 @@ const transformerMatrixInverse = [
 const toInt = (x: string) => parseInt(x, 10)
 const floor = Math.floor
 
-interface XYZ {
+export interface XYZ {
 	x: number
 	y: number
 	z: number
 }
 
-interface LAB {
+export interface LAB {
 	l: number
 	a: number
 	b: number
 }
 
-interface RGB {
+export interface RGB {
 	r: number
 	g: number
 	b: number
 }
 
-interface HSL {
+export interface HSL {
 	h: number
 	s: number
 	l: number

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -1,7 +1,7 @@
 const {defineConfig} = require('tsup')
 
 module.exports = defineConfig({
-	entry: ['./src/index.ts'],
+	entry: ['./src/index.ts', './src/compose.ts'],
 	bundle: true,
 	dts: true,
 	format: ['esm', 'cjs'],


### PR DESCRIPTION
While the initial API isn't hard to change, I'd like to avoid a breaking change for something so tiny. 

Addition of `tocolor/compose` to be able to get composable functions. 

Making it easier to do things like this  (even though, tocolor already does come with most of these functions already. 

```js
const hslToHex = rgbToHex(hslToRGB({h: 0, s: 0, l: 100}))
```